### PR TITLE
enhance setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 vendor
-comoser.lock
+composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,11 @@
   },
   "autoload": {
     "psr-4": {
-      "Exceptions\\": "./src",
+      "Exceptions\\": "./src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
       "Tests\\": "./tests"
     }
   }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -39,9 +39,6 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src</directory>
-            <exclude>
-                <file>src/</file>
-            </exclude>
         </whitelist>
     </filter>
 


### PR DESCRIPTION
# Changed log
- Fix typo: `composer.lock` defined in `.gitignore` file.
- Add the `.phpunit.result.cache` to be defined in `.gitignore` file because we don't need to let cached unit test result file be under the Git version control.
This cached file is generated since using the `PHPUnit 8+`.
- Define the `autoload-dev` block in `composer.json` to let test classes can be loaded automatically.
- Removing unnecessary `exclude` tag in `phpunit.xml.dist`.
- According to this [reference](https://phpunit.readthedocs.io/en/8.2/organizing-tests.html), removing the `phpunit.xml` because the `phpunit.xml.dist` has already been existed.
It's better than `phpunit.xml` file.