### PR TITLE
Add ClientException to resolve issue #5

### DIFF
--- a/src/HTTP/ClientException.php
+++ b/src/HTTP/ClientException.php
@@ -1,0 +1,46 @@
+<?php namespace Exceptions\HTTP {
+
+use Exceptions\DomainException;
+
+/**
+ * HTTPException class
+ *
+ * A base class for more generic HTTP client 4xx error exceptions
+ * to extend
+ *
+ * @package Exceptions\HTTP
+ *
+ * @author  Jason Napolitano <https://github.com/jason-napolitano>
+ * @version 0.0.3
+ * @since   0.0.1
+ * @license MIT <https://opensource.org/licenses/MIT>
+ */
+class ClientException extends DomainException
+{
+    /**
+     * The exception message
+     *
+     * @var string $message The exception message
+     */
+    protected $message = 'An HTTP error was encountered';
+
+    /**
+     * The HTTP status code
+     *
+     * @var int $statusCode The HTTP status code
+     */
+    protected $statusCode = 400;
+
+    /**
+     * Constructor for ClientException
+     *
+     * @param string $statusCode
+     * @param string $message
+     */
+    public function __construct(int $statusCode, string $message)
+    {
+        $this->statusCode = $statusCode;
+        $this->message = $message;
+    }
+}
+}

--- a/tests/HTTP/ClientExceptionTest.php
+++ b/tests/HTTP/ClientExceptionTest.php
@@ -1,0 +1,39 @@
+<?php namespace Tests\HTTP {
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ClientExceptionTest Test Case
+ *
+ * Testing \Exceptions\HTTP\ClientException
+ *
+ * @package Tests\HTTP
+ *
+ * @author  Jason Napolitano <https://github.com/jason-napolitano>
+ * @version 0.0.3
+ * @since   0.0.1
+ * @license MIT <https://opensource.org/licenses/MIT>
+ */
+class ClientExceptionTest extends TestCase
+{
+    /**
+     * Here, we are expecting the \Exceptions\HTTP\ClientException
+     * to be thrown
+     *
+     * @return void|mixed
+     */
+    public function testExpectClientException()
+    {
+        // We are expecting the Exception to be thrown ...
+        $this->expectException(\Exceptions\HTTP\ClientException::class);
+
+        // Simple test
+        if (2 > 1) {
+            throw new \Exceptions\HTTP\ClientException(400, 'Bad Request');
+        }
+    }
+
+    //-------------------------------------------------------------------------
+}
+
+}


### PR DESCRIPTION
# Changed log
- Resolves HTTP `ClientException` class in issue #5.
- Adding the `ClientException` class and create a constructor to let developers can assign the HTTP status code and response message.